### PR TITLE
add explicit video_quality setting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,15 @@ configuration.username = MUX_TOKEN_ID
 configuration.password = MUX_TOKEN_SECRET
 mux_client = mux_python.ApiClient(configuration)
 assets_api = mux_python.AssetsApi(mux_client)
+#
+# "plus" video quality is required for mp4 support
+#    https://docs.mux.com/guides/use-video-quality-levels
+#
+# "basic" video quality is free, but does not have mp4 support (currently, that might change after I write this)
+#
+# Best to be explicit with video_quality because the default video_quality setting can be configured at the organization-level.
+#
+video_quality = "plus"
 
 @bot.event
 async def on_ready():
@@ -112,6 +121,7 @@ async def create_mux_asset(video_url):
         input=input_settings,
         mp4_support=mp4_quality,
         playback_policy=['public']
+        video_quality=video_quality
     )
     asset = assets_api.create_asset(create_asset_request)
     logger.info(f"Asset created with ID: {asset.data.id}")


### PR DESCRIPTION
- `"plus"` video quality is required for mp4 support. See https://docs.mux.com/guides/use-video-quality-levels
- The other option, `"basic"` video quality is great because it's free encoding, but it does not have mp4 support (at least not currently, but that might change in some way in the future)

Since this integration uses mp4 support, it's a good idea to be explicit about setting `video_quality` in the API request because the default `video_quality` setting can be configured at the organization-level.

---

# TODO

- [ ] Test this change (I did not do the steps of actually installing it in a discord server.